### PR TITLE
Fix Jekyll build: broken includes in layouts and incorrect baseurl

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@
 title: MCF
 email: ventas@mcfsoluciones.com
 description: > # this means to ignore newlines until "baseurl:"
-baseurl: "/" # the subpath of your site, e.g. /blog/
+baseurl: "" # the subpath of your site, e.g. /blog/
 url: "https://mcfsoluciones.com/" # the base hostname & protocol for your site
 
 twitter_username:

--- a/_layouts/ins_front.html
+++ b/_layouts/ins_front.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <body>
-{% include incidencias.html %}
+{{ content }}
 </body>
 
 </html>

--- a/_layouts/movs_front.html
+++ b/_layouts/movs_front.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <body id="page-top">
-  {% include movimientos.html %}
+  {{ content }}
 </body>
 
 </html>


### PR DESCRIPTION
- _layouts/movs_front.html: Replace `{% include movimientos.html %}` with `{{ content }}` — the include file never existed in _includes/, causing the build to fail with IOError
- _layouts/ins_front.html: Same fix for `{% include incidencias.html %}`
- _config.yml: Change baseurl from "/" to "" to prevent double-slash in generated URL paths

https://claude.ai/code/session_012Qf33miZmu8QXo2HfQM5gq