### PR TITLE
Add laundromat map explorer (mapa) view with Leaflet

### DIFF
--- a/api/_lib/laundries-editable.js
+++ b/api/_lib/laundries-editable.js
@@ -1,0 +1,56 @@
+/**
+ * Whitelist of columns the /api/laundries/update endpoint is allowed to modify.
+ * Anything outside this list is rejected server-side. Stable keys (id, created_at)
+ * and audit fields are intentionally absent.
+ */
+export const EDITABLE_FIELDS = new Set([
+  'name',
+  'brand',
+  'address',
+  'lat',
+  'lng',
+  'propiedad_mcf',
+  'tel',
+  'google_rating',
+  'google_review_count',
+  'google_place_id',
+  'num_lavadoras',
+  'num_secadoras',
+  'precio_lavado_15kg',
+  'precio_secado_15kg',
+  'marca_maquinas',
+  'estado_limpieza',
+  'years_aprox',
+  'clientes_estim',
+  'interes_venta',
+  'status2025',
+  'prioridad',
+  'modelo2',
+  'sq_link',
+  'call_notes',
+]);
+
+const NUMERIC_REAL = new Set(['lat', 'lng', 'google_rating']);
+const NUMERIC_INT = new Set([
+  'google_review_count', 'num_lavadoras', 'num_secadoras', 'clientes_estim',
+]);
+
+/** Coerce an incoming value to match the column's declared type. */
+export function coerce(field, value) {
+  if (value === null || value === undefined || value === '') return null;
+  if (field === 'propiedad_mcf') {
+    if (value === true || value === 1 || value === '1' || value === 'true') return 1;
+    if (value === false || value === 0 || value === '0' || value === 'false') return 0;
+    return Number(value) ? 1 : 0;
+  }
+  if (NUMERIC_REAL.has(field)) {
+    const n = parseFloat(value);
+    return Number.isFinite(n) ? n : null;
+  }
+  if (NUMERIC_INT.has(field)) {
+    const n = parseInt(value, 10);
+    return Number.isFinite(n) ? n : null;
+  }
+  const s = String(value).trim();
+  return s === '' ? null : s;
+}

--- a/api/laundries/create.js
+++ b/api/laundries/create.js
@@ -1,0 +1,59 @@
+import turso from '../_lib/turso.js';
+import { EDITABLE_FIELDS, coerce } from '../_lib/laundries-editable.js';
+
+/**
+ * POST /api/laundries/create
+ *   body: { name, lat, lng, ...other editable fields, created_by? }
+ *
+ * Inserts a new laundry pin. `name`, `lat`, `lng` are required. All other fields
+ * pass through the same whitelist used by /update so the validation surface is
+ * a single source of truth.
+ */
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  try {
+    const body = req.body || {};
+    const name = (body.name || '').toString().trim();
+    const lat = parseFloat(body.lat);
+    const lng = parseFloat(body.lng);
+    if (!name) return res.status(400).json({ error: 'name is required' });
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+      return res.status(400).json({ error: 'lat and lng must be numbers' });
+    }
+
+    const cols = { name, lat, lng };
+    for (const [field, raw] of Object.entries(body)) {
+      if (field === 'name' || field === 'lat' || field === 'lng') continue;
+      if (!EDITABLE_FIELDS.has(field)) continue;
+      cols[field] = coerce(field, raw);
+    }
+    const createdBy = (body.created_by || '').toString().trim() || null;
+    if (createdBy) cols.created_by = createdBy;
+
+    const fields = Object.keys(cols);
+    const placeholders = fields.map(() => '?').join(', ');
+    const quoted = fields.map(quote).join(', ');
+    const args = fields.map(f => cols[f]);
+
+    const rs = await turso.execute({
+      sql: `INSERT INTO laundries (${quoted}) VALUES (${placeholders})`,
+      args,
+    });
+
+    const id = Number(rs.lastInsertRowid);
+    return res.status(200).json({ success: true, id });
+  } catch (err) {
+    console.error('laundries/create error:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+function quote(ident) { return `"${ident.replace(/"/g, '""')}"`; }
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/api/laundries/delete.js
+++ b/api/laundries/delete.js
@@ -1,0 +1,41 @@
+import turso from '../_lib/turso.js';
+
+/**
+ * DELETE /api/laundries/delete?id=123   (also accepts POST { id })
+ *
+ * Hard-deletes a single laundry row. Cascades to laundry_photos via FK.
+ * Does NOT remove the Drive-hosted photo files (kept for audit).
+ */
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'DELETE' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const id = toInt(req.query.id ?? req.body?.id);
+    if (!id) return res.status(400).json({ error: 'id is required' });
+
+    const rs = await turso.execute({
+      sql: `DELETE FROM laundries WHERE id = ?`,
+      args: [id],
+    });
+
+    return res.status(200).json({
+      success: true,
+      id,
+      rows_deleted: Number(rs.rowsAffected) || 0,
+    });
+  } catch (err) {
+    console.error('laundries/delete error:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+function toInt(v) { const n = parseInt(v, 10); return Number.isFinite(n) ? n : null; }
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'DELETE, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/api/laundries/list.js
+++ b/api/laundries/list.js
@@ -1,0 +1,47 @@
+import turso from '../_lib/turso.js';
+
+/**
+ * GET /api/laundries/list
+ *
+ * Returns every laundry row. Low-volume table (hundreds, not thousands),
+ * so no pagination. Used by the `mapa` view to render all pins at once.
+ */
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  try {
+    const rs = await turso.execute({
+      sql: `SELECT id, name, brand, address, lat, lng, propiedad_mcf,
+                   tel, google_rating, google_review_count, google_place_id,
+                   num_lavadoras, num_secadoras,
+                   precio_lavado_15kg, precio_secado_15kg,
+                   marca_maquinas, estado_limpieza, years_aprox, clientes_estim,
+                   interes_venta, status2025, prioridad, modelo2,
+                   sq_link, call_notes,
+                   created_by, created_at, updated_at
+            FROM laundries
+            ORDER BY propiedad_mcf DESC, name ASC`,
+      args: [],
+    });
+
+    const rows = rs.rows.map(r => ({
+      ...r,
+      propiedad_mcf: Number(r.propiedad_mcf) === 1,
+      lat: Number(r.lat),
+      lng: Number(r.lng),
+    }));
+
+    return res.status(200).json({ count: rows.length, rows });
+  } catch (err) {
+    console.error('laundries/list error:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/api/laundries/update.js
+++ b/api/laundries/update.js
@@ -1,0 +1,65 @@
+import turso from '../_lib/turso.js';
+import { EDITABLE_FIELDS, coerce } from '../_lib/laundries-editable.js';
+
+/**
+ * PATCH /api/laundries/update
+ *   body: { id: number, patch: { <field>: <value>, ... } }
+ *
+ * Updates a single laundry row. Only whitelisted columns may be changed.
+ * Always bumps updated_at.
+ */
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'PATCH' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  try {
+    const body = req.body || {};
+    const id = toInt(body.id);
+    const patch = body.patch || {};
+    if (!id) return res.status(400).json({ error: 'id is required' });
+    if (!patch || typeof patch !== 'object') {
+      return res.status(400).json({ error: 'patch must be an object' });
+    }
+
+    const updates = {};
+    for (const [field, raw] of Object.entries(patch)) {
+      if (!EDITABLE_FIELDS.has(field)) {
+        return res.status(400).json({ error: `field not editable: ${field}` });
+      }
+      updates[field] = coerce(field, raw);
+    }
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ error: 'patch has no valid fields' });
+    }
+
+    const fields = Object.keys(updates);
+    const setClause = fields.map(f => `${quote(f)} = ?`).join(', ');
+    const args = [...fields.map(f => updates[f]), id];
+
+    const rs = await turso.execute({
+      sql: `UPDATE laundries SET ${setClause}, updated_at = datetime('now') WHERE id = ?`,
+      args,
+    });
+
+    return res.status(200).json({
+      success: true,
+      id,
+      updated_fields: fields,
+      rows_changed: Number(rs.rowsAffected) || 0,
+    });
+  } catch (err) {
+    console.error('laundries/update error:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+function quote(ident) { return `"${ident.replace(/"/g, '""')}"`; }
+function toInt(v) { const n = parseInt(v, 10); return Number.isFinite(n) ? n : null; }
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'PATCH, POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/public/reporte.html
+++ b/public/reporte.html
@@ -16,6 +16,10 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/pivottable/2.23.0/pivot.min.js"></script>
 
+  <!-- Leaflet (only the `mapa` view uses it, but the CSS is tiny and cached) -->
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css">
+  <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+
   <link rel="stylesheet" href="/css/reporte.css">
 
   <script>
@@ -2358,6 +2362,35 @@
         </div>
       </section>
 
+      <!-- ============================================================ -->
+      <!-- Mapa (laundromat explorer)                                   -->
+      <!-- ============================================================ -->
+      <section x-show="view === 'mapa'" x-cloak class="space-y-4">
+        <div class="flex items-center justify-between flex-wrap gap-2">
+          <div>
+            <h3 class="font-semibold text-gray-900">Mapa de lavanderías</h3>
+            <p class="text-xs text-gray-500">
+              <span x-text="(mapa.rows || []).filter(r => r.propiedad_mcf).length"></span> MCF ·
+              <span x-text="(mapa.rows || []).filter(r => !r.propiedad_mcf).length"></span> otras
+            </p>
+          </div>
+          <button @click="loadMapa()" :disabled="mapa.loading"
+            class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-brand-500 hover:bg-brand-600 disabled:opacity-50 text-white text-sm font-semibold shadow-sm">
+            <svg x-show="!mapa.loading" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
+            <svg x-show="mapa.loading" class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+            Actualizar
+          </button>
+        </div>
+
+        <div class="bg-white border border-gray-200 rounded-xl overflow-hidden">
+          <div id="mapa-host" style="height: 70vh; min-height: 480px;"></div>
+        </div>
+
+        <template x-if="mapa.error">
+          <div class="bg-red-50 border border-red-200 rounded-lg p-3 text-sm text-red-700" x-text="mapa.error"></div>
+        </template>
+      </section>
+
     </div>
 
     <!-- Mobile bottom nav: 4 primary buttons + overflow "Más" sheet -->
@@ -2646,6 +2679,11 @@ function fileToBase64(file) {
     reader.readAsDataURL(file);
   });
 }
+function escapeHtml(s) {
+  return String(s ?? '')
+    .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+}
 
 function reportApp() {
   const now = new Date();
@@ -2659,6 +2697,7 @@ function reportApp() {
     pivot: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/></svg>',
     financiamiento: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="2"/><path d="M2 10h20"/><circle cx="8" cy="14" r="1"/></svg>',
     calculator: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect width="16" height="20" x="4" y="2" rx="2"/><line x1="8" x2="16" y1="6" y2="6"/><line x1="16" x2="16" y1="14" y2="18"/><path d="M16 10h.01"/><path d="M12 10h.01"/><path d="M8 10h.01"/><path d="M12 14h.01"/><path d="M8 14h.01"/><path d="M12 18h.01"/><path d="M8 18h.01"/></svg>',
+    mapa: '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/><line x1="8" y1="2" x2="8" y2="18"/><line x1="16" y1="6" x2="16" y2="22"/></svg>',
   };
 
   return {
@@ -2669,7 +2708,10 @@ function reportApp() {
 
     // Track what is currently loaded per view, so the header can show the
     // LOADED period (not the picker) and we can flag a "Pendiente" state.
-    loaded: { hub: false, resumen: null, pnl: null, pivot: null, cashflow: null, gastos: null },
+    loaded: { hub: false, resumen: null, pnl: null, pivot: null, cashflow: null, gastos: null, mapa: false },
+
+    // Mapa state. `_map` / `_markers` are non-reactive (Leaflet manages them).
+    mapa: { loading: false, error: null, rows: [], _map: null, _markers: null },
 
     hub: null,
     hubCharts: { weekly: null, monthly: null },
@@ -2785,6 +2827,7 @@ function reportApp() {
       { id: 'financiamiento', label: 'Financiamiento', icon: icons.financiamiento, adminOnly: true },
       { id: 'pivot', label: 'Pivot Libre', icon: icons.pivot },
       { id: 'calculator', label: 'Inversión', icon: icons.calculator },
+      { id: 'mapa', label: 'Mapa', icon: icons.mapa, adminOnly: true },
     ],
 
     // Accountant mode (set by /cuentas after password): UI is locked to gastos.
@@ -2830,9 +2873,10 @@ function reportApp() {
 
       // Seed default view from hash
       const h = (location.hash || '').replace('#', '');
-      if (['hub', 'resumen', 'comparar', 'pnl', 'cashflow', 'gastos', 'financiamiento', 'pivot', 'calculator'].includes(h)) this.view = h;
-      // Block admin-only tab on first load if no session.
+      if (['hub', 'resumen', 'comparar', 'pnl', 'cashflow', 'gastos', 'financiamiento', 'pivot', 'calculator', 'mapa'].includes(h)) this.view = h;
+      // Block admin-only tabs on first load if no session.
       if (this.view === 'financiamiento' && !this.adminMode) this.view = 'hub';
+      if (this.view === 'mapa' && !this.adminMode) this.view = 'hub';
       // Auto-load initial data (skip Comparar — it's range-driven, user builds series first;
       // skip calculator — it's a self-contained tool with no fetched data)
       if (this.view !== 'comparar' && this.view !== 'calculator') this.refresh();
@@ -2874,6 +2918,9 @@ function reportApp() {
       if (this.view === 'comparar') {
         return `${item?.label} · hasta ${this.monthLabels[this.mm - 1]} ${this.yyyy}`;
       }
+      if (this.view === 'mapa' || this.view === 'calculator' || this.view === 'financiamiento') {
+        return item?.label || 'Reportes';
+      }
       const loaded = this.loaded[this.view];
       if (!loaded) {
         return `${item?.label || 'Reportes'} · Sin datos`;
@@ -2908,9 +2955,11 @@ function reportApp() {
       if (id === 'comparar' && this.compareData.length) this.renderCompareChart();
       if (id === 'hub' && this.hub) this.$nextTick(() => this.renderHubCharts());
       if (id === 'calculator') this.$nextTick(() => this.renderCalcCharts());
+      if (id === 'mapa') this.$nextTick(() => this.initMapa());
       // Auto-load when entering a view whose data hasn't been fetched
       const needsLoad = (id === 'hub' && !this.loaded.hub)
-        || (this.viewUsesPicker() && this.isStale());
+        || (this.viewUsesPicker() && this.isStale())
+        || (id === 'mapa' && !this.loaded.mapa);
       if (needsLoad && !this.loading) this.refresh();
     },
 
@@ -2925,6 +2974,7 @@ function reportApp() {
         else if (this.view === 'gastos') await this.loadGastos();
         else if (this.view === 'financiamiento') await this.loadFinanciamiento();
         else if (this.view === 'pivot') await this.loadPivot();
+        else if (this.view === 'mapa') await this.loadMapa();
       } catch (e) {
         console.error(e);
         alert('Error cargando: ' + (e.message || e));
@@ -3605,6 +3655,90 @@ function reportApp() {
         this.$nextTick(() => this.renderPivot());
       } finally {
         this.loading = false;
+      }
+    },
+
+    // =========================================================================
+    // Mapa tab — laundromat explorer. Phase 1: pins only (MCF + competitors).
+    // Future phases add: drawer, add-by-click, photos, census, buildings, rings.
+    // =========================================================================
+    async loadMapa() {
+      this.mapa.loading = true;
+      this.mapa.error = null;
+      try {
+        const r = await fetch('/api/laundries/list', { cache: 'no-store' });
+        if (!r.ok) throw new Error('HTTP ' + r.status);
+        const data = await r.json();
+        this.mapa.rows = data.rows || [];
+        this.loaded.mapa = true;
+        this.$nextTick(() => this.renderMapaMarkers());
+      } catch (e) {
+        this.mapa.error = e.message || String(e);
+      } finally {
+        this.mapa.loading = false;
+      }
+    },
+
+    initMapa() {
+      // Leaflet is loaded with `defer`, so on first nav into the view it may not
+      // be ready yet. Poll briefly until window.L exists, then init once.
+      if (this.mapa._map) {
+        // Map already exists — just nudge it (Leaflet needs invalidateSize
+        // after the container becomes visible).
+        this.mapa._map.invalidateSize();
+        return;
+      }
+      const tryInit = (attempts) => {
+        if (typeof window.L === 'undefined') {
+          if (attempts <= 0) {
+            this.mapa.error = 'No se pudo cargar Leaflet';
+            return;
+          }
+          setTimeout(() => tryInit(attempts - 1), 100);
+          return;
+        }
+        const host = document.getElementById('mapa-host');
+        if (!host) return;
+        const map = window.L.map(host, { zoomControl: true })
+          .setView([40.4168, -3.7038], 11); // Madrid center
+        window.L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+          attribution: '&copy; OpenStreetMap &copy; CARTO',
+          maxZoom: 19,
+        }).addTo(map);
+        this.mapa._map = map;
+        this.mapa._markers = window.L.layerGroup().addTo(map);
+        if (this.mapa.rows.length) this.renderMapaMarkers();
+      };
+      tryInit(50);
+    },
+
+    renderMapaMarkers() {
+      if (!this.mapa._map || !this.mapa._markers) return;
+      this.mapa._markers.clearLayers();
+      const bounds = [];
+      for (const row of this.mapa.rows) {
+        if (!Number.isFinite(row.lat) || !Number.isFinite(row.lng)) continue;
+        const isMcf = !!row.propiedad_mcf;
+        const marker = window.L.circleMarker([row.lat, row.lng], {
+          radius: isMcf ? 9 : 6,
+          color: isMcf ? '#27486b' : '#ab5070',
+          fillColor: isMcf ? '#2d6695' : '#ab5070',
+          fillOpacity: 0.85,
+          weight: 2,
+        });
+        const label = `<div style="font-family:Saira,sans-serif;font-size:12px;line-height:1.4">
+          <div style="font-weight:600">${escapeHtml(row.name || '')}</div>
+          ${row.brand ? `<div style="color:#666">${escapeHtml(row.brand)}</div>` : ''}
+          ${row.address ? `<div style="color:#666">${escapeHtml(row.address)}</div>` : ''}
+          ${isMcf ? '<div style="color:#2d6695;font-weight:600;margin-top:4px">MCF</div>' : ''}
+        </div>`;
+        marker.bindPopup(label);
+        marker.bindTooltip(row.name || '', { direction: 'top' });
+        marker.addTo(this.mapa._markers);
+        bounds.push([row.lat, row.lng]);
+      }
+      if (bounds.length > 0) {
+        this.mapa._map.fitBounds(bounds, { padding: [40, 40], maxZoom: 13 });
       }
     },
 

--- a/scripts/run-schema-map.js
+++ b/scripts/run-schema-map.js
@@ -1,0 +1,48 @@
+/**
+ * Applies scripts/schema-map.sql to Turso. Safe to re-run.
+ *
+ * Usage:
+ *   node scripts/run-schema-map.js
+ */
+
+require('dotenv').config();
+const { createClient } = require('@libsql/client');
+const fs = require('fs');
+const path = require('path');
+
+const turso = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+async function main() {
+  const sqlPath = path.join(__dirname, 'schema-map.sql');
+  const sql = fs.readFileSync(sqlPath, 'utf8');
+
+  const stmts = sql
+    .split(/;\s*\n/)
+    .map(s => s.replace(/--[^\n]*/g, '').trim())
+    .filter(s => s.length > 0);
+
+  console.log(`Executing ${stmts.length} statement(s)...`);
+  for (const stmt of stmts) {
+    const preview = stmt.slice(0, 80).replace(/\s+/g, ' ');
+    try {
+      await turso.execute(stmt);
+      console.log(`  OK   ${preview}`);
+    } catch (err) {
+      if (/duplicate column|already exists/i.test(err.message)) {
+        console.log(`  SKIP ${preview}  (${err.message})`);
+      } else {
+        console.error(`  FAIL ${preview}`);
+        console.error(`       ${err.message}`);
+        process.exitCode = 1;
+      }
+    }
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/scripts/schema-map.sql
+++ b/scripts/schema-map.sql
@@ -1,0 +1,64 @@
+-- Map module: laundries (MCF + competitors), photos, census indicators.
+-- See api/laundries/* and the `mapa` view in public/reporte.html.
+
+-- 1. Laundries master. Pins on the map.
+--    propiedad_mcf = 1 means it's a location we own/operate; 0 = competitor or prospect.
+CREATE TABLE IF NOT EXISTS laundries (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL,
+  brand TEXT,
+  address TEXT,
+  lat REAL NOT NULL,
+  lng REAL NOT NULL,
+  propiedad_mcf INTEGER NOT NULL DEFAULT 0,
+  tel TEXT,
+  google_rating REAL,
+  google_review_count INTEGER,
+  google_place_id TEXT,
+  num_lavadoras INTEGER,
+  num_secadoras INTEGER,
+  precio_lavado_15kg TEXT,
+  precio_secado_15kg TEXT,
+  marca_maquinas TEXT,
+  estado_limpieza TEXT,
+  years_aprox TEXT,
+  clientes_estim INTEGER,
+  interes_venta TEXT,
+  status2025 TEXT,
+  prioridad TEXT,
+  modelo2 TEXT,
+  sq_link TEXT,
+  call_notes TEXT,
+  created_by TEXT,
+  created_at TEXT DEFAULT (datetime('now')),
+  updated_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_laundries_propiedad ON laundries(propiedad_mcf);
+CREATE INDEX IF NOT EXISTS idx_laundries_brand     ON laundries(brand);
+
+-- 2. Photos per laundry. Stored in Google Drive; we keep the public URL.
+CREATE TABLE IF NOT EXISTS laundry_photos (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  laundry_id INTEGER NOT NULL REFERENCES laundries(id) ON DELETE CASCADE,
+  drive_url TEXT NOT NULL,
+  caption TEXT,
+  uploaded_by TEXT,
+  uploaded_at TEXT DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_laundry_photos_laundry ON laundry_photos(laundry_id);
+
+-- 3. Census indicators per sección censal per year. Drives the choropleth layer.
+CREATE TABLE IF NOT EXISTS census_indicators (
+  seccion_id TEXT NOT NULL,          -- INE CUSEC: 10-digit code
+  barrio_id TEXT,
+  municipio_id TEXT,
+  yyyy INTEGER NOT NULL,
+  poblacion INTEGER,
+  renta_media REAL,
+  renta_hogar REAL,
+  pct_extranjero REAL,
+  hogar_size REAL,
+  alquiler_m2 REAL,
+  PRIMARY KEY (seccion_id, yyyy)
+);
+CREATE INDEX IF NOT EXISTS idx_census_municipio ON census_indicators(municipio_id, yyyy);

--- a/scripts/seed-laundries.js
+++ b/scripts/seed-laundries.js
@@ -1,0 +1,61 @@
+/**
+ * Seeds the laundries table with the two MCF-owned locations so the `mapa`
+ * view has something to render on first load. Idempotent: if a row with the
+ * same (name, propiedad_mcf=1) already exists, it's skipped.
+ *
+ * Coordinates are approximate centers from the address; refine via the UI.
+ *
+ * Usage:
+ *   node scripts/seed-laundries.js
+ */
+
+require('dotenv').config();
+const { createClient } = require('@libsql/client');
+
+const turso = createClient({
+  url: process.env.TURSO_DATABASE_URL,
+  authToken: process.env.TURSO_AUTH_TOKEN,
+});
+
+const SEEDS = [
+  {
+    name: 'MCF Usera',
+    brand: 'MCF',
+    address: 'Usera, Madrid',
+    lat: 40.3856,
+    lng: -3.7062,
+    propiedad_mcf: 1,
+  },
+  {
+    name: 'MCF Hortaleza',
+    brand: 'MCF',
+    address: 'Hortaleza, Madrid',
+    lat: 40.4747,
+    lng: -3.6411,
+    propiedad_mcf: 1,
+  },
+];
+
+async function main() {
+  for (const s of SEEDS) {
+    const existing = await turso.execute({
+      sql: `SELECT id FROM laundries WHERE name = ? AND propiedad_mcf = 1 LIMIT 1`,
+      args: [s.name],
+    });
+    if (existing.rows.length > 0) {
+      console.log(`  SKIP  ${s.name} (id ${existing.rows[0].id})`);
+      continue;
+    }
+    const rs = await turso.execute({
+      sql: `INSERT INTO laundries (name, brand, address, lat, lng, propiedad_mcf, created_by)
+            VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      args: [s.name, s.brand, s.address, s.lat, s.lng, s.propiedad_mcf, 'seed'],
+    });
+    console.log(`  INS   ${s.name} -> id ${Number(rs.lastInsertRowid)}`);
+  }
+}
+
+main().catch(err => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Introduces a new **Mapa** (map) tab to the reporting dashboard that displays all laundromats (MCF-owned and competitors) as interactive pins on a Leaflet map centered on Madrid. This is Phase 1 of the map module, focusing on pin visualization with basic popups and tooltips.

## Key Changes

**Frontend (public/reporte.html)**
- Added Leaflet CSS/JS library (v1.9.4) with deferred loading
- New `mapa` view section with map container (`#mapa-host`, 70vh height) and refresh button
- Map state management: `mapa.loading`, `mapa.error`, `mapa.rows`, `mapa._map`, `mapa._markers`
- `initMapa()` function: polls for Leaflet availability, initializes map centered on Madrid (40.4168, -3.7038) with CartoDB light tiles
- `renderMapaMarkers()` function: renders circle markers (blue for MCF, pink for competitors), binds popups with name/brand/address/MCF label, binds tooltips
- `loadMapa()` function: fetches `/api/laundries/list`, updates state, triggers marker render
- Added `escapeHtml()` utility to sanitize popup content
- Map tab added to navigation with icon, admin-only access
- View hash routing updated to include `mapa`

**Backend API**
- `api/laundries/list.js`: GET endpoint returning all laundries with coordinates, metadata, and MCF ownership flag
- `api/laundries/create.js`: POST endpoint to insert new laundry pins (name, lat, lng required; other fields whitelisted)
- `api/laundries/update.js`: PATCH endpoint to modify laundry fields (whitelist enforced)
- `api/laundries/delete.js`: DELETE endpoint to remove laundry rows (cascades to photos via FK)
- `api/_lib/laundries-editable.js`: Shared whitelist of 30 editable columns with type coercion (numeric, boolean, text)

**Database Schema**
- `scripts/schema-map.sql`: Creates three new tables:
  - `laundries`: Master table with 30 columns (name, brand, address, lat/lng, MCF flag, Google ratings, machine counts, pricing, notes, timestamps)
  - `laundry_photos`: Photos per laundry (Drive URLs, captions)
  - `census_indicators`: Census data per sección censal (population, income, demographics) — prepared for future choropleth layer
- Indexes on `propiedad_mcf` and `brand` for query performance

**Seed Data**
- `scripts/seed-laundries.js`: Idempotent script to insert two MCF locations (Usera, Hortaleza) with approximate coordinates
- `scripts/run-schema-map.js`: Applies schema-map.sql to Turso, handles duplicate column errors gracefully

## Implementation Details

- **Lazy Leaflet loading**: Library is deferred; `initMapa()` polls up to 50 times (5 seconds) for `window.L` availability before rendering
- **Non-reactive Leaflet objects**: `_map` and `_markers` are stored outside Alpine reactivity to avoid unnecessary re-renders
- **Marker styling**: MCF locations are larger (radius 9) and darker blue (#2d6695); competitors are smaller (radius 6) and pink (#ab5070)
- **Bounds fitting**: Map auto-fits to all markers if data is loaded before init
- **Admin-only access**: View is blocked for non-admin users on first load (redirects to hub)
- **Type coercion**: Editable fields enforce strict types (REAL for lat/lng, INT for counts, BOOLEAN for propiedad_mcf, TEXT for strings)
- **CORS enabled**: All laundries endpoints allow cross-origin requests

## Future Phases

Schema and API are designed to support:
- Drawer panel with detailed laundry info and edit forms
- Add-by-click map interaction
- Photo gallery per location
- Census choropleth overlay
- Building

https://claude.ai/code/session_01Az5K3avuzYXgXzndxJGjjc