### PR TITLE
Fix Edificios layer: protomaps-leaflet CDN path

### DIFF
--- a/public/reporte.html
+++ b/public/reporte.html
@@ -24,7 +24,7 @@
   <script defer src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
   <!-- protomaps-leaflet renders Catastro buildings from PMTiles archives.
        Defer + load after Leaflet (window.L). -->
-  <script defer src="https://unpkg.com/protomaps-leaflet@4.0.1/dist/protomaps-leaflet.min.js"></script>
+  <script defer src="https://unpkg.com/protomaps-leaflet@4.0.1/dist/protomaps-leaflet.js"></script>
 
   <link rel="stylesheet" href="/css/reporte.css">
 


### PR DESCRIPTION
protomaps-leaflet@4.0.1 has no .min.js (404); use dist/protomaps-leaflet.js so window.protomapsL loads. Fixes 'protomaps-leaflet no esta cargado' on the buildings layer.