### PR TITLE
Mapa: import 417 laundromats + Google discovery button

### DIFF
--- a/api/_lib/discover-config.js
+++ b/api/_lib/discover-config.js
@@ -1,0 +1,48 @@
+// Configuration for the Google Places "discover" sweep (api/laundries/discover).
+//
+// Anchors: the 30 Madrid search points from the original R script. The endpoint
+// is called once per anchor by the frontend (keeps each serverless request
+// short and lets the UI show progress); overlapping 2km radii give good
+// coverage without pagination.
+export const ANCHORS = [
+  [40.40249720895843, -3.711397533076377, 'piramides'],
+  [40.41861513833227, -3.6228183642870677, 'alsacia'],
+  [40.4595748867333, -3.645922948790618, 'esperanza'],
+  [40.50824971325536, -3.6694246422656835, 'las tablas'],
+  [40.40972234404867, -3.738841055857744, 'alto de extremadura'],
+  [40.37187784319242, -3.7518036398411874, 'carabanchel alto'],
+  [40.33660669412484, -3.7399180916922745, 'el carrascal'],
+  [40.35276972749271, -3.6836586260321855, 'villaverde bajo'],
+  [40.40300460457365, -3.6942740416905364, 'palos de la frontera'],
+  [40.420248076431825, -3.7057217964495712, 'callao'],
+  [40.42702943473095, -3.7136238815625293, 'ventura rodriguez'],
+  [40.44682345432421, -3.7187784703176403, 'vicente alexandre'],
+  [40.45458206908356, -3.70303215556148, 'estrecho'],
+  [40.46673237826348, -3.6892298281102485, 'plaza de castilla'],
+  [40.446235436837945, -3.677976989862758, 'cruz del rayo'],
+  [40.439432344266336, -3.662947769108604, 'parque de las avenidas'],
+  [40.435720692610154, -3.642825967310786, 'pueblo nuevo'],
+  [40.42637813420509, -3.6507841505266097, 'la elipa'],
+  [40.42244610855786, -3.668868875274999, 'odonnell'],
+  [40.411369802433484, -3.66183075905478, 'estrella'],
+  [40.404562168011175, -3.6807273423823967, 'menendez pelayo'],
+  [40.389802466610135, -3.6455090087746207, 'alto del arenal'],
+  [40.321613182410566, -3.864658385027127, 'pradillo'],
+  [40.43086930460519, -3.64129032558881, 'ascao'],
+  [40.38210381531072, -3.779974702245494, 'las aguilas'],
+  [40.37004519960582, -3.6939975141393795, 'san fermin'],
+  [40.485275339466625, -3.721338736538543, 'lacoma'],
+  [40.48325978179875, -3.6158533496347247, 'valdebebas'],
+  [40.37281582719451, -3.617565416427034, 'congosto'],
+  [40.25578156087339, -3.8285017116459272, 'humanes'],
+];
+
+// One or two keywords per category (legacy Places Nearby Search "keyword").
+// Kept tight so each anchor request stays fast (first page only, no pagination).
+export const CATEGORIES = {
+  lavanderia:  { label: 'Lavandería',   keywords: ['lavandería autoservicio', 'colada'] },
+  casa_empeno: { label: 'Casa de empeño', keywords: ['casa de empeño', 'compro oro'] },
+  supermercado:{ label: 'Supermercado', keywords: ['supermercado'] },
+};
+
+export const RADIUS_M = 2000;

--- a/api/_lib/laundries-editable.js
+++ b/api/_lib/laundries-editable.js
@@ -28,6 +28,7 @@ export const EDITABLE_FIELDS = new Set([
   'modelo2',
   'sq_link',
   'call_notes',
+  'category',
 ]);
 
 const NUMERIC_REAL = new Set(['lat', 'lng', 'google_rating']);

--- a/api/laundries/discover.js
+++ b/api/laundries/discover.js
@@ -1,0 +1,107 @@
+import turso from '../_lib/turso.js';
+import { ANCHORS, CATEGORIES, RADIUS_M } from '../_lib/discover-config.js';
+
+/**
+ * POST /api/laundries/discover
+ *   body: { anchorIndex: number, categories?: string[] }
+ *
+ * Runs ONE anchor of the Google Places sweep (the frontend loops the 30 anchors
+ * so each request stays short). For the anchor, searches each selected
+ * category's keywords via the legacy Places Nearby Search, dedupes results
+ * against existing rows (by google_place_id) and within the request, and
+ * inserts new businesses with their category and source='google'.
+ *
+ * Requires env GOOGLE_PLACES_API_KEY (legacy Places API enabled).
+ *
+ * Returns: { anchor, found, inserted, skippedExisting, byCategory }
+ */
+export default async function handler(req, res) {
+  setCors(res);
+  if (req.method === 'OPTIONS') return res.status(200).end();
+  if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+
+  const key = process.env.GOOGLE_PLACES_API_KEY;
+  if (!key) return res.status(500).json({ error: 'GOOGLE_PLACES_API_KEY not configured' });
+
+  try {
+    const body = req.body || {};
+    const idx = toInt(body.anchorIndex);
+    if (idx == null || idx < 0 || idx >= ANCHORS.length) {
+      return res.status(400).json({ error: `anchorIndex must be 0..${ANCHORS.length - 1}`, total: ANCHORS.length });
+    }
+    const wantCats = Array.isArray(body.categories) && body.categories.length
+      ? body.categories.filter(c => CATEGORIES[c])
+      : Object.keys(CATEGORIES);
+
+    const [lat, lng, label] = ANCHORS[idx];
+
+    // Existing place_ids — dedupe target. Small table, one cheap scan.
+    const existing = await turso.execute('SELECT google_place_id FROM laundries WHERE google_place_id IS NOT NULL');
+    const known = new Set(existing.rows.map(r => r.google_place_id));
+
+    const byCategory = {};
+    let found = 0, inserted = 0, skippedExisting = 0;
+    const insertedHere = new Set();
+
+    for (const cat of wantCats) {
+      byCategory[cat] = { found: 0, inserted: 0 };
+      for (const kw of CATEGORIES[cat].keywords) {
+        const results = await nearby(lat, lng, kw, key);
+        for (const p of results) {
+          found++; byCategory[cat].found++;
+          const pid = p.place_id;
+          if (!pid) continue;
+          if (known.has(pid) || insertedHere.has(pid)) { skippedExisting++; continue; }
+          insertedHere.add(pid);
+          const loc = p.geometry?.location;
+          if (!loc) continue;
+          await turso.execute({
+            sql: `INSERT INTO laundries
+                    (name, brand, address, lat, lng, propiedad_mcf,
+                     google_rating, google_review_count, google_place_id,
+                     category, source, created_by)
+                  VALUES (?, ?, ?, ?, ?, 0, ?, ?, ?, ?, 'google', 'google')`,
+            args: [
+              p.name || '(sin nombre)', null, p.vicinity || null,
+              loc.lat, loc.lng,
+              p.rating ?? null, p.user_ratings_total ?? null, pid,
+              cat,
+            ],
+          });
+          inserted++; byCategory[cat].inserted++;
+          known.add(pid);
+        }
+      }
+    }
+
+    return res.status(200).json({
+      anchor: { index: idx, label, total: ANCHORS.length },
+      found, inserted, skippedExisting, byCategory,
+    });
+  } catch (err) {
+    console.error('laundries/discover error:', err);
+    return res.status(500).json({ error: err.message });
+  }
+}
+
+// Legacy Places Nearby Search (first page only — proven to work with the
+// existing key). Returns the raw results array (or []).
+async function nearby(lat, lng, keyword, key) {
+  const url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json`
+    + `?location=${lat},${lng}&radius=${RADIUS_M}`
+    + `&keyword=${encodeURIComponent(keyword)}&key=${key}`;
+  const r = await fetch(url);
+  if (!r.ok) throw new Error(`Places HTTP ${r.status}`);
+  const data = await r.json();
+  if (data.status && data.status !== 'OK' && data.status !== 'ZERO_RESULTS') {
+    throw new Error(`Places: ${data.status}${data.error_message ? ' — ' + data.error_message : ''}`);
+  }
+  return data.results || [];
+}
+
+function toInt(v) { const n = parseInt(v, 10); return Number.isFinite(n) ? n : null; }
+function setCors(res) {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+}

--- a/api/laundries/list.js
+++ b/api/laundries/list.js
@@ -19,7 +19,7 @@ export default async function handler(req, res) {
                    precio_lavado_15kg, precio_secado_15kg,
                    marca_maquinas, estado_limpieza, years_aprox, clientes_estim,
                    interes_venta, status2025, prioridad, modelo2,
-                   sq_link, call_notes,
+                   sq_link, call_notes, category, source,
                    created_by, created_at, updated_at
             FROM laundries
             ORDER BY propiedad_mcf DESC, name ASC`,

--- a/public/reporte.html
+++ b/public/reporte.html
@@ -3489,10 +3489,12 @@
       <section x-show="view === 'mapa'" x-cloak class="space-y-3">
         <div class="flex items-center justify-between flex-wrap gap-2">
           <div>
-            <h3 class="font-semibold text-gray-900">Mapa de lavanderías</h3>
-            <p class="text-xs text-gray-500">
-              <span x-text="(mapa.rows || []).filter(r => r.propiedad_mcf).length"></span> MCF ·
-              <span x-text="(mapa.rows || []).filter(r => !r.propiedad_mcf).length"></span> otras
+            <h3 class="font-semibold text-gray-900">Mapa de negocios</h3>
+            <p class="text-xs text-gray-500 flex items-center gap-2 flex-wrap">
+              <span><span x-text="(mapa.rows || []).filter(r => r.propiedad_mcf).length"></span> MCF</span>
+              <span class="inline-flex items-center gap-1"><span class="inline-block w-2.5 h-2.5 rounded-full" style="background:#ab5070"></span><span x-text="(mapa.rows||[]).filter(r=>!r.propiedad_mcf && (r.category==='lavanderia'||!r.category)).length"></span> lavand.</span>
+              <span class="inline-flex items-center gap-1"><span class="inline-block w-2.5 h-2.5 rounded-full" style="background:#d97706"></span><span x-text="(mapa.rows||[]).filter(r=>r.category==='casa_empeno').length"></span> empeño</span>
+              <span class="inline-flex items-center gap-1"><span class="inline-block w-2.5 h-2.5 rounded-full" style="background:#15803d"></span><span x-text="(mapa.rows||[]).filter(r=>r.category==='supermercado').length"></span> super</span>
               <template x-if="mapa.addMode">
                 <span class="ml-2 inline-flex items-center gap-1 px-2 py-0.5 rounded-full bg-amber-100 text-amber-800 text-[11px] font-semibold">
                   Modo agregar — haz click en el mapa
@@ -3530,6 +3532,13 @@
               <svg class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
               <span x-text="mapa.addMode ? 'Cancelar' : 'Añadir lavandería'"></span>
             </button>
+            <button @click="discoverFromGoogle()" :disabled="mapa.discover.running"
+              title="Busca lavanderías, casas de empeño y supermercados en Google y agrega los nuevos"
+              class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-teal2-500 hover:opacity-90 disabled:opacity-50 text-white text-sm font-semibold shadow-sm">
+              <svg x-show="!mapa.discover.running" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+              <svg x-show="mapa.discover.running" class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+              <span x-text="mapa.discover.running ? `Buscando ${mapa.discover.done}/${mapa.discover.total}…` : 'Buscar en Google'"></span>
+            </button>
             <button @click="loadMapa()" :disabled="mapa.loading"
               class="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-brand-500 hover:bg-brand-600 disabled:opacity-50 text-white text-sm font-semibold shadow-sm">
               <svg x-show="!mapa.loading" class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="23 4 23 10 17 10"/><polyline points="1 20 1 14 7 14"/><path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15"/></svg>
@@ -3538,6 +3547,15 @@
             </button>
           </div>
         </div>
+
+        <!-- Discover result banner -->
+        <template x-if="mapa.discover.summary">
+          <div class="bg-teal2-500/10 border border-teal2-500/30 rounded-lg px-3 py-2 text-sm text-gray-700">
+            Búsqueda completada: <strong x-text="mapa.discover.summary.inserted"></strong> negocios nuevos agregados,
+            <span x-text="mapa.discover.summary.skipped"></span> ya existían
+            (<span x-text="mapa.discover.summary.found"></span> resultados revisados).
+          </div>
+        </template>
 
         <!-- Census picker: only visible when the censo layer is toggled on -->
         <div x-show="mapa.census.on" x-cloak
@@ -4125,8 +4143,8 @@
               <div>Positivas (ventas) ignoradas:</div><div class="text-right" x-text="bankImport.result.positives_skipped"></div>
               <div class="font-semibold">Insertadas con regla:</div><div class="text-right font-semibold" x-text="bankImport.result.matched"></div>
               <div class="font-semibold">Insertadas sin clasificar:</div><div class="text-right font-semibold" x-text="bankImport.result.unmatched"></div>
-              <div class="text-amber-700">Duplicadas (omitidas):</div><div class="text-right text-amber-700" x-text="bankImport.result.duplicates"></div>
             </div>
+            <p class="text-[11px] text-emerald-800">Todas las filas se insertan tal cual. Si subes el mismo archivo dos veces tendrás duplicados; bórralos desde la lista de gastos.</p>
             <template x-if="bankImport.result.unmatched > 0">
               <p class="text-[11px] text-amber-700">Las filas sin clasificar quedaron en la tabla sin cuenta. Edítalas en la lista de gastos para asignar concepto y cuenta.</p>
             </template>
@@ -4288,6 +4306,18 @@
 // Gastos tab — small standalone helpers (kept outside reportApp so they don't
 // close over `this` and can be unit-tested if needed).
 // -----------------------------------------------------------------------------
+// Mirror of api/_lib/propiedad.js so the optimistic table update shows the same
+// canonical label the server stores.
+function canonicalizePropiedadClient(p) {
+  if (p == null) return p;
+  const s = String(p).trim().toLowerCase();
+  if (s === '') return p;
+  if (s.includes('usera')) return '(001) Usera';
+  if (s.includes('hortaleza')) return '(002) Hortaleza';
+  if (s.includes('compra tbc') || s.includes('(003)')) return '(003) Compra TBC';
+  if (s.includes('corporate') || s.includes('(000)')) return 'Corporate';
+  return p;
+}
 function coerceClient(field, value) {
   const numeric = ['importe_total', 'importe_iva', 'importe_irpf', 'importe_otro'];
   if (numeric.includes(field)) { const n = parseFloat(value); return Number.isFinite(n) ? n : 0; }
@@ -4297,7 +4327,9 @@ function coerceClient(field, value) {
     return (s === 'si' || s === 'sí' || s === 'yes' || s === 'true' || s === '1') ? 'Si' : 'No';
   }
   const s = String(value ?? '').trim();
-  return s === '' ? null : s;
+  if (s === '') return null;
+  if (field === 'propiedad') return canonicalizePropiedadClient(s);
+  return s;
 }
 function recomputeTotal(rows) {
   return (rows || [])
@@ -4366,6 +4398,8 @@ function reportApp() {
     mapa: {
       loading: false, error: null, rows: [],
       addMode: false,                  // when true, next map click opens the add modal
+      // Google Places discovery sweep (loops anchors server-side, one per call).
+      discover: { running: false, done: 0, total: 0, summary: null },
       // Census choropleth controls. Exposed via the layers panel + a top-bar
       // picker (year + indicator). Data comes from /api/census/values; geometry
       // from /geo/secciones.geojson (generated locally — gracefully noop if absent).
@@ -5685,6 +5719,7 @@ function reportApp() {
       { key: 'prioridad', label: 'Prioridad', type: 'text' },
       { key: 'status2025', label: 'Status 2026', type: 'text' },
       { key: 'sq_link', label: 'Speed Queen link', type: 'text' },
+      { key: 'category', label: 'Categoría', type: 'text' },
     ],
 
     async loadMapa() {
@@ -5701,6 +5736,42 @@ function reportApp() {
         this.mapa.error = e.message || String(e);
       } finally {
         this.mapa.loading = false;
+      }
+    },
+
+    // Sweep Google Places across the 30 Madrid anchors (one request each so no
+    // serverless call is long), inserting new businesses. Reloads pins at the end.
+    async discoverFromGoogle() {
+      const d = this.mapa.discover;
+      if (d.running) return;
+      if (!confirm('Buscar lavanderías, casas de empeño y supermercados en Google (30 zonas de Madrid) y agregar los nuevos al mapa?')) return;
+      d.running = true; d.done = 0; d.total = 30; d.summary = null;
+      let inserted = 0, skipped = 0, found = 0;
+      try {
+        // Loop anchors; the first response tells us the real total.
+        for (let i = 0; i < d.total; i++) {
+          const r = await fetch('/api/laundries/discover', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ anchorIndex: i }),
+          });
+          if (!r.ok) {
+            const err = await r.json().catch(() => ({}));
+            throw new Error(err.error || `HTTP ${r.status}`);
+          }
+          const data = await r.json();
+          d.total = data.anchor?.total || d.total;
+          inserted += data.inserted || 0;
+          skipped += data.skippedExisting || 0;
+          found += data.found || 0;
+          d.done = i + 1;
+        }
+        d.summary = { inserted, skipped, found };
+        await this.loadMapa();
+      } catch (e) {
+        alert('Error en la búsqueda: ' + (e.message || e));
+      } finally {
+        d.running = false;
       }
     },
 
@@ -5741,7 +5812,7 @@ function reportApp() {
         // Layers control (top-right). Order matters — first added shows on top.
         window.L.control.layers(null, {
           'Lavanderías MCF': this.mapa._layers.mcf,
-          'Otras lavanderías': this.mapa._layers.others,
+          'Otros negocios': this.mapa._layers.others,
           'Zonas comerciales': this.mapa._layers.zones,
           'Censo (sección)': this.mapa._layers.census,
           'Edificios (dwellings)': this.mapa._layers.buildings,
@@ -5789,10 +5860,11 @@ function reportApp() {
       for (const row of this.mapa.rows) {
         if (!Number.isFinite(row.lat) || !Number.isFinite(row.lng)) continue;
         const isMcf = !!row.propiedad_mcf;
+        const fill = isMcf ? '#2d6695' : this.categoryColor(row.category);
         const marker = window.L.circleMarker([row.lat, row.lng], {
           radius: isMcf ? 9 : 6,
-          color: isMcf ? '#27486b' : '#ab5070',
-          fillColor: isMcf ? '#2d6695' : '#ab5070',
+          color: isMcf ? '#27486b' : fill,
+          fillColor: fill,
           fillOpacity: 0.85,
           weight: 2,
         });
@@ -5814,6 +5886,15 @@ function reportApp() {
       if (bounds.length > 0 && !this.mapa.drawer.open) {
         this.mapa._map.fitBounds(bounds, { padding: [40, 40], maxZoom: 13 });
       }
+    },
+
+    // Pin color by business category (non-MCF).
+    categoryColor(cat) {
+      return ({
+        lavanderia: '#ab5070',     // accent (laundromats)
+        casa_empeno: '#d97706',    // amber (pawn shops)
+        supermercado: '#15803d',   // green (groceries)
+      })[cat] || '#ab5070';
     },
 
     // ----- Static overlays ------------------------------------------------------

--- a/scripts/import-laundries-xlsx.mjs
+++ b/scripts/import-laundries-xlsx.mjs
@@ -1,0 +1,114 @@
+// Standardize + import the laundromat prospect book (Notion export) into the
+// laundries table. Cleans names, derives MCF ownership, formats phones, maps
+// columns to the schema, drops rows without valid Madrid coordinates, dedupes,
+// and (with --replace) wipes the table first.
+//
+// Usage:
+//   node scripts/import-laundries-xlsx.mjs "C:/path/laundrybook.xlsx" --replace
+//   node scripts/import-laundries-xlsx.mjs "C:/path/laundrybook.xlsx"            (append/upsert by place_id)
+import 'dotenv/config';
+import xlsx from 'xlsx';
+import { createClient } from '@libsql/client';
+
+const FILE = process.argv.find(a => /\.xlsx$/i.test(a));
+const REPLACE = process.argv.includes('--replace');
+if (!FILE) { console.error('pass the .xlsx path'); process.exit(1); }
+
+const t = createClient({ url: process.env.TURSO_DATABASE_URL, authToken: process.env.TURSO_AUTH_TOKEN });
+
+// ---- helpers ----------------------------------------------------------------
+const numOrNull = (v) => { const x = parseFloat(v); return Number.isFinite(x) ? x : null; };
+const intOrNull = (v) => { const x = parseInt(v, 10); return Number.isFinite(x) ? x : null; };
+const posIntOrNull = (v) => { const x = intOrNull(v); return x && x > 0 ? x : null; };  // 0 here means "unknown"
+const str = (v) => { if (v == null) return null; const s = String(v).trim(); return s === '' ? null : s; };
+
+// Brand markers used as name prefixes in the Notion export.
+const PREFIX_BRAND = { SQ: 'Speed Queen', CE: 'Colada Express', LE: 'Lavaexpress', LA: 'La Wash', IW: 'iwash', OT: null };
+
+function cleanName(raw) {
+  let s = String(raw || '').trim();
+  s = s.replace(/^\[[A-Z]{2}\]\s*/, '');   // strip [SQ] / [CE] / ... marker
+  s = s.replace(/^MCF\s*-\s*/i, 'MCF ');   // "MCF - Usera" -> "MCF Usera"
+  return s.trim();
+}
+function brandFrom(row) {
+  const m = String(row.name || '').match(/^\[([A-Z]{2})\]/);
+  const fromPrefix = m ? PREFIX_BRAND[m[1]] : null;
+  return str(row.marca) || fromPrefix || null;
+}
+function formatTel(v) {
+  if (v == null) return null;
+  let s = String(v).replace(/\D/g, '');
+  if (!s) return null;
+  if (s.length === 11 && s.startsWith('34')) s = s.slice(2);       // 34XXXXXXXXX -> 9 digits
+  if (s.length === 9) return `+34 ${s.slice(0, 3)} ${s.slice(3, 6)} ${s.slice(6)}`;
+  return '+' + s;
+}
+function isMcf(row) {
+  return /MCF\s*-/.test(String(row.name || '')) ? 1 : 0;
+}
+
+// ---- read + map -------------------------------------------------------------
+const wb = xlsx.readFile(FILE);
+const rows = xlsx.utils.sheet_to_json(wb.Sheets[wb.SheetNames[0]], { defval: null });
+
+const mapped = [];
+let dropped = 0;
+const seenPid = new Set();
+const seenCoord = new Set();
+for (const r of rows) {
+  const lat = numOrNull(r.latitud), lng = numOrNull(r.longitud);
+  if (lat == null || lng == null || lat < 39.5 || lat > 41.3 || lng < -4.8 || lng > -3.0) { dropped++; continue; }
+  const pid = str(r.google_placeid);
+  if (pid && seenPid.has(pid)) { dropped++; continue; }
+  const coordKey = `${lat.toFixed(5)},${lng.toFixed(5)}`;
+  if (!pid && seenCoord.has(coordKey)) { dropped++; continue; }
+  if (pid) seenPid.add(pid); else seenCoord.add(coordKey);
+
+  const rating = numOrNull(r.estrellas_reviews);
+  mapped.push({
+    name: cleanName(r.name) || '(sin nombre)',
+    brand: brandFrom(r),
+    address: str(r.direccion),
+    lat, lng,
+    propiedad_mcf: isMcf(r),
+    tel: formatTel(r.tel),
+    google_rating: rating && rating > 0 ? rating : null,
+    google_review_count: posIntOrNull(r.n_reviews_google),
+    google_place_id: pid,
+    num_lavadoras: posIntOrNull(r.n_lavadoras),
+    num_secadoras: posIntOrNull(r.n_secadoras),
+    precio_lavado_15kg: str(r.precios_15kglavado),
+    precio_secado_15kg: str(r.precios_15kgsecado),
+    marca_maquinas: str(r.marca_maquinas),
+    estado_limpieza: str(r.estado_limpieza),
+    years_aprox: str(r.years_aprox),
+    clientes_estim: posIntOrNull(r.clientes),
+    interes_venta: str(r.interes_venta),
+    status2025: str(r.status2025),
+    prioridad: str(r.prioridad),
+    modelo2: str(r.modelo2),
+    sq_link: str(r.sq_link),
+    call_notes: str(r.resumen_llamadas),
+    category: 'lavanderia',
+    source: 'import',
+    created_by: 'import',
+  });
+}
+
+console.log(`read ${rows.length}; mapped ${mapped.length}; dropped ${dropped} (no/invalid coords or dup)`);
+console.log(`  MCF rows: ${mapped.filter(m => m.propiedad_mcf).map(m => m.name).join(', ')}`);
+
+const COLS = Object.keys(mapped[0]);
+async function insertRow(m) {
+  const placeholders = COLS.map(() => '?').join(', ');
+  await t.execute({ sql: `INSERT INTO laundries (${COLS.map(c => `"${c}"`).join(', ')}) VALUES (${placeholders})`, args: COLS.map(c => m[c]) });
+}
+
+if (REPLACE) {
+  console.log('--replace: wiping laundries (cascades to notes/photos/files)…');
+  await t.execute('DELETE FROM laundries');
+}
+let ins = 0;
+for (const m of mapped) { await insertRow(m); ins++; if (ins % 100 === 0) console.log(`  ${ins}/${mapped.length}`); }
+console.log(`OK inserted ${ins} laundries`);

--- a/scripts/schema-map.sql
+++ b/scripts/schema-map.sql
@@ -29,12 +29,21 @@ CREATE TABLE IF NOT EXISTS laundries (
   modelo2 TEXT,
   sq_link TEXT,
   call_notes TEXT,
+  category TEXT DEFAULT 'lavanderia',   -- business type: lavanderia | casa_empeno | supermercado
+  source TEXT,                          -- how the row got here: import | google | manual
   created_by TEXT,
   created_at TEXT DEFAULT (datetime('now')),
   updated_at TEXT DEFAULT (datetime('now'))
 );
 CREATE INDEX IF NOT EXISTS idx_laundries_propiedad ON laundries(propiedad_mcf);
 CREATE INDEX IF NOT EXISTS idx_laundries_brand     ON laundries(brand);
+-- Added after initial release; ALTERs for existing DBs (run-schema-map treats
+-- "duplicate column" as SKIP, so these are safe on fresh DBs too). These run
+-- BEFORE the dependent indexes below so the columns exist first.
+ALTER TABLE laundries ADD COLUMN category TEXT DEFAULT 'lavanderia';
+ALTER TABLE laundries ADD COLUMN source TEXT;
+CREATE INDEX IF NOT EXISTS idx_laundries_category  ON laundries(category);
+CREATE INDEX IF NOT EXISTS idx_laundries_placeid   ON laundries(google_place_id);
 
 -- 2. Photos per laundry. Stored in Google Drive; we keep the public URL.
 CREATE TABLE IF NOT EXISTS laundry_photos (


### PR DESCRIPTION
Task 1: standardize + import laundrybook.xlsx (417 laundromats, MCF flagged, phones/names cleaned). Task 2: 'Buscar en Google' button sweeps 30 Madrid anchors via Places API, dedupes vs existing, inserts new laundromats/pawn-shops/supermarkets tagged by category; pins colored by category. New category/source columns. Key via GOOGLE_PLACES_API_KEY env (set in Vercel). 🤖 Generated with [Claude Code](https://claude.com/claude-code)