### PR TITLE
Mapa: on-demand Google discovery around a clicked ring

### DIFF
--- a/api/laundries/discover.js
+++ b/api/laundries/discover.js
@@ -25,15 +25,30 @@ export default async function handler(req, res) {
 
   try {
     const body = req.body || {};
-    const idx = toInt(body.anchorIndex);
-    if (idx == null || idx < 0 || idx >= ANCHORS.length) {
-      return res.status(400).json({ error: `anchorIndex must be 0..${ANCHORS.length - 1}`, total: ANCHORS.length });
+
+    // Two modes:
+    //   - grid sweep: { anchorIndex } uses a fixed Madrid anchor (full sweep button)
+    //   - ad-hoc point: { lat, lng, radius? } searches around an arbitrary click
+    //     (the ring "Buscar en Google aquí" button)
+    let lat, lng, label, radius = RADIUS_M;
+    if (body.lat != null && body.lng != null) {
+      lat = Number(body.lat); lng = Number(body.lng);
+      if (!Number.isFinite(lat) || !Number.isFinite(lng)) {
+        return res.status(400).json({ error: 'lat/lng must be numbers' });
+      }
+      const r = Number(body.radius);
+      if (Number.isFinite(r) && r > 0) radius = Math.min(r, 50000);
+      label = `(${lat.toFixed(4)}, ${lng.toFixed(4)})`;
+    } else {
+      const idx = toInt(body.anchorIndex);
+      if (idx == null || idx < 0 || idx >= ANCHORS.length) {
+        return res.status(400).json({ error: `provide lat/lng or anchorIndex (0..${ANCHORS.length - 1})`, total: ANCHORS.length });
+      }
+      [lat, lng, label] = ANCHORS[idx];
     }
     const wantCats = Array.isArray(body.categories) && body.categories.length
       ? body.categories.filter(c => CATEGORIES[c])
       : Object.keys(CATEGORIES);
-
-    const [lat, lng, label] = ANCHORS[idx];
 
     // Existing place_ids — dedupe target. Small table, one cheap scan.
     const existing = await turso.execute('SELECT google_place_id FROM laundries WHERE google_place_id IS NOT NULL');
@@ -46,7 +61,7 @@ export default async function handler(req, res) {
     for (const cat of wantCats) {
       byCategory[cat] = { found: 0, inserted: 0 };
       for (const kw of CATEGORIES[cat].keywords) {
-        const results = await nearby(lat, lng, kw, key);
+        const results = await nearby(lat, lng, radius, kw, key);
         for (const p of results) {
           found++; byCategory[cat].found++;
           const pid = p.place_id;
@@ -75,7 +90,8 @@ export default async function handler(req, res) {
     }
 
     return res.status(200).json({
-      anchor: { index: idx, label, total: ANCHORS.length },
+      anchor: { index: toInt(body.anchorIndex), label, total: ANCHORS.length },
+      center: { lat, lng, radius },
       found, inserted, skippedExisting, byCategory,
     });
   } catch (err) {
@@ -86,9 +102,9 @@ export default async function handler(req, res) {
 
 // Legacy Places Nearby Search (first page only — proven to work with the
 // existing key). Returns the raw results array (or []).
-async function nearby(lat, lng, keyword, key) {
+async function nearby(lat, lng, radius, keyword, key) {
   const url = `https://maps.googleapis.com/maps/api/place/nearbysearch/json`
-    + `?location=${lat},${lng}&radius=${RADIUS_M}`
+    + `?location=${lat},${lng}&radius=${Math.round(radius)}`
     + `&keyword=${encodeURIComponent(keyword)}&key=${key}`;
   const r = await fetch(url);
   if (!r.ok) throw new Error(`Places HTTP ${r.status}`);

--- a/public/reporte.html
+++ b/public/reporte.html
@@ -3703,6 +3703,24 @@
                     </div>
                   </div>
                 </template>
+
+                <!-- On-demand Google discovery around this exact ring -->
+                <div class="border-t border-gray-100 pt-2">
+                  <button @click="discoverAtRing()" :disabled="mapa.ring.discover.running"
+                    class="w-full inline-flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md bg-teal2-500 hover:opacity-90 disabled:opacity-50 text-white text-xs font-semibold">
+                    <svg x-show="!mapa.ring.discover.running" class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+                    <svg x-show="mapa.ring.discover.running" class="w-3.5 h-3.5 animate-spin" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12a9 9 0 1 1-6.219-8.56"/></svg>
+                    <span x-text="mapa.ring.discover.running ? 'Buscando…' : 'Buscar negocios en Google aquí'"></span>
+                  </button>
+                  <template x-if="mapa.ring.discover.result">
+                    <div class="text-[11px] text-gray-600 mt-1.5 text-center">
+                      <strong x-text="mapa.ring.discover.result.inserted"></strong> nuevos ·
+                      <span x-text="mapa.ring.discover.result.skipped"></span> ya estaban
+                      (<span x-text="mapa.ring.discover.result.found"></span> revisados)
+                    </div>
+                  </template>
+                </div>
+
                 <div class="text-[10px] text-gray-400 pt-1">Mueve el anillo con el botón «Anillo».</div>
               </div>
             </template>
@@ -4427,6 +4445,8 @@ function reportApp() {
         demo: null,                  // { sections, poblacion, renta_media, pct_extranjero, hogar_size, alquiler_m2, year }
         censusState: 'idle',         // 'idle' | 'loading' | 'ready' | 'error'
         _census: null,               // parsed { year, points: [...] }
+        // On-demand Google discovery around this ring (single point).
+        discover: { running: false, result: null },
       },
       drawer: {
         open: false, id: null, row: null, saving: false, error: null,
@@ -5775,6 +5795,33 @@ function reportApp() {
       }
     },
 
+    // On-demand Google discovery around the current ring only (single point).
+    async discoverAtRing() {
+      const r = this.mapa.ring;
+      const dd = r.discover;
+      if (dd.running || r.lat == null) return;
+      dd.running = true; dd.result = null;
+      try {
+        const resp = await fetch('/api/laundries/discover', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ lat: r.lat, lng: r.lng, radius: r.radiusM }),
+        });
+        if (!resp.ok) {
+          const err = await resp.json().catch(() => ({}));
+          throw new Error(err.error || `HTTP ${resp.status}`);
+        }
+        const data = await resp.json();
+        dd.result = { inserted: data.inserted || 0, skipped: data.skippedExisting || 0, found: data.found || 0 };
+        await this.loadMapa();          // refresh pins
+        this.computeRingStats();        // refresh in-ring competitor counts
+      } catch (e) {
+        alert('Error en la búsqueda: ' + (e.message || e));
+      } finally {
+        dd.running = false;
+      }
+    },
+
     initMapa() {
       // Leaflet has `defer`, so the script may not have run yet on first visit.
       if (this.mapa._map) {
@@ -6128,6 +6175,7 @@ function reportApp() {
         r._circle = window.L.circle([lat, lng], opts).addTo(map);
       }
       r.active = true;
+      r.discover.result = null;   // stale once the ring moves/resizes
       this.computeRingStats();
     },
 


### PR DESCRIPTION
Adds a 'Buscar negocios en Google aqui' button to the ring stats panel. Searches Places around the exact ring center+radius, dedupes vs existing, inserts new businesses, refreshes pins. The discover endpoint now accepts {lat,lng,radius} for ad-hoc points in addition to the grid {anchorIndex}. 🤖 Generated with [Claude Code](https://claude.com/claude-code)